### PR TITLE
商品一覧表示機能を実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,14 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, only: [:new]
 
+  def index
+    @items = Item.includes(:user).order("created_at DESC")
+  end
+
+  # def index
+  #   @items = Item.all
+  # end
+
   def new
     @item = Item.new
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,10 +5,6 @@ class ItemsController < ApplicationController
     @items = Item.includes(:user).order("created_at DESC")
   end
 
-  # def index
-  #   @items = Item.all
-  # end
-
   def new
     @item = Item.new
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,10 +127,11 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +142,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <%= item.price %>円<br><%= item.delivery_charge.name %>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,6 +154,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>


### PR DESCRIPTION
#What
商品一覧表示機能を実装

#why
Furimaのトップページに出品した商品を一覧表示するため

#エビデンス
- 画像が表示されており、画像がリンク切れなどになっていないこと
- 出品した商品の一覧表示ができていること
- 上から、出品された日時が新しい順に表示されること
- 「画像/価格/商品名」の3つの情報について表示できていること
- 売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
https://gyazo.com/bf66b7ffd0d155cb858ebca7bfe89ccd


- ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/b4dae9c9870633278cf09b62221990c3
